### PR TITLE
Follows inheritance with a namespace

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -91,7 +91,7 @@ module ActiveModel
         if serializer_class
           serializer_class
         elsif klass.superclass
-          get_serializer_for(klass.superclass)
+          get_serializer_for(klass.superclass, namespace)
         else
           nil # No serializer found
         end

--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -337,7 +337,7 @@ module ActiveModel
     # @return [Enumerator<Association>]
     def associations(include_directive = ActiveModelSerializers.default_include_directive, include_slice = nil)
       include_slice ||= include_directive
-      return Enumerator.new unless object
+      return Enumerator.new { } unless object
 
       Enumerator.new do |y|
         self.class._reflections.each do |key, reflection|

--- a/test/serializers/serializer_for_with_namespace_test.rb
+++ b/test/serializers/serializer_for_with_namespace_test.rb
@@ -7,6 +7,7 @@ module ActiveModel
         attributes :title, :author_name
         associations :publisher, :pages
       end
+      class Ebook < Book; end
       class Page < ::Model; attributes :number, :text end
       class Publisher < ::Model; attributes :name end
 
@@ -82,6 +83,11 @@ module ActiveModel
           }
         }
         assert_equal expected, result
+      end
+
+      test 'follows inheritance with a namespace' do
+        serializer = ActiveModel::Serializer.serializer_for(Ebook.new, namespace: Api::V3)
+        assert_equal Api::V3::BookSerializer, serializer
       end
     end
   end


### PR DESCRIPTION

#### Purpose

When using a namespace it wasn't properly following the model inheritance, so for example if you have an `Ebook` model that inherits from `Book` while using `Api::V3` namespace, it wouldn't try `Api::V3::BookSerializer` but `BookSerializer` instead.

#### Changes

I added namespace to the recursion call in 
https://github.com/rails-api/active_model_serializers/blob/b1de431731f8ea8c92c7cb56e4eb3232f1f77e94/lib/active_model/serializer.rb#L94
